### PR TITLE
Change Next.js' moduleResolution to Bundler

### DIFF
--- a/configs/next.json
+++ b/configs/next.json
@@ -4,7 +4,7 @@
     "target": "ES5",
     "module": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
This PR changes the `moduleResolution` of the `next` config from `Node` to `Bundler`.

It is also set as default since Next.js [v13.4.11](https://github.com/vercel/next.js/releases/tag/v13.4.11) ([PR](https://github.com/vercel/next.js/pull/51957)).

Related issues are also fixed before being set as default in Next.js [v13.4.5](https://github.com/vercel/next.js/releases/tag/v13.4.5) ([PR](https://github.com/vercel/next.js/pull/51065)) which makes it pretty stable choice to migrate to.